### PR TITLE
feat: display ChatGPT model options

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,7 +3,7 @@ import {
   useGenerativeAiSettings,
   useGithubAuthToken,
 } from "./hooks/use_settings";
-import { defaultGenerativeAiSettings, CHATGPT_MODELS_URL } from "./constants";
+import { defaultGenerativeAiSettings, availableModels, CHATGPT_MODELS_URL } from "./constants";
 import { GenerativeAiConnector } from "./types";
 
 const SettingsComponent: React.FC = () => {
@@ -157,10 +157,9 @@ const SettingsComponent: React.FC = () => {
             <button onClick={handleModelReset}>Reset to default</button>
             <p>Here are some available ChatGPT model options:</p>
             <p>
-              <b>gpt-4o </b>, 
-              <b>gpt-4o-mini </b>, 
-              <b>gpt-4-turbo </b>, 
-              <b>gpt-4 </b>, and <b>gpt-3.5-turbo</b>
+              <b>
+              {availableModels.slice(0, -1).join(", ")} and {availableModels[availableModels.length - 1]}
+              </b>
             </p>
             <p>For a complete list of models, please check the <a href={CHATGPT_MODELS_URL} target="_blank" rel="noopener noreferrer">ChatGPT models page</a>.</p>
           </fieldset>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -138,15 +138,31 @@ const SettingsComponent: React.FC = () => {
           </fieldset>
           <fieldset>
             <label>
-              Model:
+              Select Model:
               <br />
               <input
                 type="text"
-                value={defaultOpenAiModel}
                 onChange={(e) => setDefaultOpenAiModel(e.target.value)}
+                list="modelOptions"
               />
             </label>
+            <datalist id="modelOptions">
+              <option value="gpt-4o" />
+              <option value="gpt-4o-mini" />
+              <option value="gpt-4o-turbo" />
+              <option value="gpt-4" />
+              <option value="gpt-3.5-turbo" />            
+            </datalist>
             <button onClick={handleModelReset}>Reset to default</button>
+            <p>Here are some available ChatGPT model options:</p>
+            <p>
+            <b>gpt-4o </b>, 
+            <b>gpt-4o-mini </b>, 
+            <b>gpt-4-turbo </b>, 
+            <b>gpt-4 </b>, and <b>gpt-3.5-turbo</b>
+            </p>
+          
+           <p>For a complete list of models, please check the <a href="https://platform.openai.com/docs/models" target="_blank">ChatGPT models page</a>.</p>
           </fieldset>
         </>
       )}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,7 +3,7 @@ import {
   useGenerativeAiSettings,
   useGithubAuthToken,
 } from "./hooks/use_settings";
-import { defaultGenerativeAiSettings } from "./constants";
+import { defaultGenerativeAiSettings, CHATGPT_MODELS_URL } from "./constants";
 import { GenerativeAiConnector } from "./types";
 
 const SettingsComponent: React.FC = () => {
@@ -157,13 +157,12 @@ const SettingsComponent: React.FC = () => {
             <button onClick={handleModelReset}>Reset to default</button>
             <p>Here are some available ChatGPT model options:</p>
             <p>
-            <b>gpt-4o </b>, 
-            <b>gpt-4o-mini </b>, 
-            <b>gpt-4-turbo </b>, 
-            <b>gpt-4 </b>, and <b>gpt-3.5-turbo</b>
+              <b>gpt-4o </b>, 
+              <b>gpt-4o-mini </b>, 
+              <b>gpt-4-turbo </b>, 
+              <b>gpt-4 </b>, and <b>gpt-3.5-turbo</b>
             </p>
-          
-           <p>For a complete list of models, please check the <a href="https://platform.openai.com/docs/models" target="_blank">ChatGPT models page</a>.</p>
+            <p>For a complete list of models, please check the <a href={CHATGPT_MODELS_URL} target="_blank" rel="noopener noreferrer">ChatGPT models page</a>.</p>
           </fieldset>
         </>
       )}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -142,6 +142,7 @@ const SettingsComponent: React.FC = () => {
               <br />
               <input
                 type="text"
+                value={defaultOpenAiModel}
                 onChange={(e) => setDefaultOpenAiModel(e.target.value)}
                 list="modelOptions"
               />

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -24,6 +24,8 @@ export const customPrompt = `## GitHub PR Title
 export const customPromptRole =
   "You are a senior software engineer providing in-depth code review feedback for a Pull Request in GitHub. Your goal is to ensure that the code is readable, maintainable, and aligns with the original proposal and coding standards.";
 
+export const CHATGPT_MODELS_URL = "https://platform.openai.com/docs/models";
+
 export const defaultGenerativeAiSettings: GenerativeAiSettings = {
   id: "default",
   openAiApiKey: "",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -26,6 +26,14 @@ export const customPromptRole =
 
 export const CHATGPT_MODELS_URL = "https://platform.openai.com/docs/models";
 
+export const availableModels = [
+  "gpt-4o",
+  "gpt-4o-mini",
+  "gpt-4o-turbo",
+  "gpt-4",
+  "gpt-3.5-turbo",
+]; 
+
 export const defaultGenerativeAiSettings: GenerativeAiSettings = {
   id: "default",
   openAiApiKey: "",


### PR DESCRIPTION
### Feature: Display ChatGPT Models
- Changed label from "Model" to "Select Model" to improve clarity for users when choosing a model.
- Incorporated the datalist element to display model options.
- Added instructions for available model options and a link to the full list of models

### Issue with Default Value
<img width="681" alt="Screenshot 2024-10-26 at 11 30 33 PM" src="https://github.com/user-attachments/assets/d5303419-62f5-4398-8f7a-775ea1411640">

* When a default AI model is set, the <datalist> dropdown only displays the current model.
* The full list of options isn't shown unless the user clears the input, potentially causing confusion.
* <datalist> behaves in a way that if the input matches one of the options exactly, the dropdown might not show the full list because it assumes the selection is already complete.

### Solution:
<img width="691" alt="Screenshot 2024-10-26 at 11 27 24 PM" src="https://github.com/user-attachments/assets/5fe225f4-e16e-4b54-8a89-b8c8ca1ab0e8">

* Removed the default OpenAI model.

<img width="682" alt="Screenshot 2024-10-26 at 11 39 26 PM" src="https://github.com/user-attachments/assets/aed9e2ac-c76d-4741-ab09-acf5a0da51f7">

* The <datalist> dropdown displays all options when the input is clicked, making it easier for the user to browse and select a model.
* By removing the default AI model from the input improves the user experience by making it clearer that the user needs to select a model from the drop down list.

it closes #5