### PR TITLE
feat: add api key visibility toggle

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,0 +1,38 @@
+.api-input {
+  font-size: 16px;
+  line-height: 140%;
+}
+
+.input-container {
+  position: relative;
+  width: 239px;
+  height: 38px;
+  margin-top: 8px;
+  display: flex;
+  border-radius: 8px;
+  border: 1px solid #c7c7ce;
+}
+
+.input-container input {
+  font-size: 16px;
+  width: 100%;
+  border: none;
+  border-radius: 8px 0 0 8px;
+  padding-left: 16px;
+  line-height: 100%;
+}
+
+.input-container button {
+  border-radius: 0px 8px 8px 0;
+  background: none;
+  border: none;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0 4px 0 4px;
+}
+
+.input-container button img {
+  width: 32px;
+  height: 32px;
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,8 +3,67 @@ import {
   useGenerativeAiSettings,
   useGithubAuthToken,
 } from "./hooks/use_settings";
-import { defaultGenerativeAiSettings, availableModels, CHATGPT_MODELS_URL } from "./constants";
+import {
+  defaultGenerativeAiSettings,
+  availableModels,
+  CHATGPT_MODELS_URL,
+} from "./constants";
 import { GenerativeAiConnector } from "./types";
+import "./App.css";
+
+const VisibleEye = () => (
+  <svg
+    width="32"
+    height="32"
+    viewBox="0 0 32 32"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <g clipPath="url(#clip0_9_3407)">
+      <path
+        d="M8.66669 16C8.66669 16 11.3334 10.6667 16 10.6667C20.6667 10.6667 23.3334 16 23.3334 16C23.3334 16 20.6667 21.3333 16 21.3333C11.3334 21.3333 8.66669 16 8.66669 16Z"
+        strokeWidth="1.6"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M16 18C17.1046 18 18 17.1046 18 16C18 14.8954 17.1046 14 16 14C14.8955 14 14 14.8954 14 16C14 17.1046 14.8955 18 16 18Z"
+        strokeWidth="1.6"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </g>
+    <defs>
+      <clipPath id="clip0_9_3407">
+        <rect width="16" height="16" fill="white" transform="translate(8 8)" />
+      </clipPath>
+    </defs>
+  </svg>
+);
+
+const HiddenEye = () => (
+  <svg
+    width="32"
+    height="32"
+    viewBox="0 0 32 32"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <g clipPath="url(#clip0_9_3408)">
+      <path
+        d="M19.96 19.96C18.8204 20.8287 17.4328 21.3099 16 21.3333C11.3334 21.3333 8.66669 16 8.66669 16C9.49595 14.4546 10.6461 13.1044 12.04 12.04M14.6 10.8267C15.0589 10.7192 15.5287 10.6655 16 10.6667C20.6667 10.6667 23.3334 16 23.3334 16C22.9287 16.7571 22.4461 17.4698 21.8934 18.1267M17.4134 17.4133C17.2303 17.6098 17.0095 17.7674 16.7641 17.8767C16.5188 17.9861 16.254 18.0448 15.9854 18.0496C15.7169 18.0543 15.4501 18.0049 15.2011 17.9043C14.9521 17.8037 14.7258 17.654 14.5359 17.4641C14.346 17.2742 14.1963 17.048 14.0957 16.7989C13.9951 16.5499 13.9457 16.2831 13.9504 16.0146C13.9552 15.7461 14.014 15.4812 14.1233 15.2359C14.2326 14.9906 14.3902 14.7698 14.5867 14.5867M8.66669 8.66666L23.3334 23.3333"
+        strokeWidth="1.6"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </g>
+    <defs>
+      <clipPath id="clip0_9_3408">
+        <rect width="16" height="16" fill="white" transform="translate(8 8)" />
+      </clipPath>
+    </defs>
+  </svg>
+);
 
 const SettingsComponent: React.FC = () => {
   const [generativeAiSettings, updateGenerativeAiSettings] =
@@ -37,6 +96,8 @@ const SettingsComponent: React.FC = () => {
   const [authToken, setAuthToken] = useState<string>(githubAuthToken);
   const [showGithubTokenSuccess, setShowGithubTokenSuccess] = useState(false);
   const [showGenerativeAiSuccess, setShowGenerativeAiSuccess] = useState(false);
+
+  const [isVisibleApiKey, setIsVisibleApiKey] = useState(false);
 
   useEffect(() => {
     setOpenAiApiKey(generativeAiSettings.openAiApiKey);
@@ -111,11 +172,12 @@ const SettingsComponent: React.FC = () => {
           <br />
           <select
             value={defaultGenerativeAiConnector}
-            onChange={(e) =>
+            onChange={(e) => {
               setDefaultGenerativeAiConnector(
                 e.target.value as GenerativeAiConnector
-              )
-            }
+              );
+              setIsVisibleApiKey(false);
+            }}
           >
             <option value="open-ai">Open AI</option>
             <option value="groq">Groq</option>
@@ -125,15 +187,24 @@ const SettingsComponent: React.FC = () => {
 
       {defaultGenerativeAiConnector === "open-ai" && (
         <>
-          <fieldset>
+          <fieldset className="api-input">
             <label>
               Open AI API Key:
-              <br />
-              <input
-                type="text"
-                value={openAiApiKey}
-                onChange={(e) => setOpenAiApiKey(e.target.value)}
-              />
+              <div className="input-container">
+                <input
+                  type={isVisibleApiKey ? "text" : "password"}
+                  value={openAiApiKey}
+                  onChange={(e) => setOpenAiApiKey(e.target.value)}
+                  placeholder="open-api-key"
+                />
+                <button
+                  type="button"
+                  className="visibility-toggle"
+                  onClick={() => setIsVisibleApiKey((prev) => !prev)}
+                >
+                  {isVisibleApiKey ? <VisibleEye /> : <HiddenEye />}
+                </button>
+              </div>
             </label>
           </fieldset>
           <fieldset>
@@ -152,31 +223,52 @@ const SettingsComponent: React.FC = () => {
               <option value="gpt-4o-mini" />
               <option value="gpt-4o-turbo" />
               <option value="gpt-4" />
-              <option value="gpt-3.5-turbo" />            
+              <option value="gpt-3.5-turbo" />
             </datalist>
             <button onClick={handleModelReset}>Reset to default</button>
             <p>Here are some available ChatGPT model options:</p>
             <p>
               <b>
-              {availableModels.slice(0, -1).join(", ")} and {availableModels[availableModels.length - 1]}
+                {availableModels.slice(0, -1).join(", ")} and{" "}
+                {availableModels[availableModels.length - 1]}
               </b>
             </p>
-            <p>For a complete list of models, please check the <a href={CHATGPT_MODELS_URL} target="_blank" rel="noopener noreferrer">ChatGPT models page</a>.</p>
+            <p>
+              For a complete list of models, please check the{" "}
+              <a
+                href={CHATGPT_MODELS_URL}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                ChatGPT models page
+              </a>
+              .
+            </p>
           </fieldset>
         </>
       )}
 
       {defaultGenerativeAiConnector === "groq" && (
         <>
-          <fieldset>
+          <fieldset className="api-input">
             <label>
               Groq API Key:
-              <br />
-              <input
-                type="text"
-                value={groqApiKey}
-                onChange={(e) => setGroqApiKey(e.target.value)}
-              />
+              <div className="input-container">
+                <input
+                  type={isVisibleApiKey ? "text" : "password"}
+                  value={groqApiKey}
+                  onChange={(e) => setGroqApiKey(e.target.value)}
+                  placeholder="groq-api-key"
+                />
+                <button
+                  type="button"
+                  className="visibility-toggle"
+                  onClick={() => setIsVisibleApiKey((prev) => !prev)}
+                  aria-label={isVisibleApiKey ? "Hide API key" : "Show API key"}
+                >
+                  {isVisibleApiKey ? <VisibleEye /> : <HiddenEye />}
+                </button>
+              </div>
             </label>
           </fieldset>
           <fieldset>

--- a/src/index.css
+++ b/src/index.css
@@ -54,6 +54,10 @@ button:focus-visible {
   outline: 4px auto -webkit-focus-ring-color;
 }
 
+svg {
+  stroke: #f9f9f9;
+}
+
 @media (prefers-color-scheme: light) {
   :root {
     color: #213547;
@@ -64,5 +68,9 @@ button:focus-visible {
   }
   button {
     background-color: #f9f9f9;
+  }
+
+  svg {
+    stroke: #1e1e1e;
   }
 }


### PR DESCRIPTION
#### Reference Issues / PRs

closes #13

#### What does this implement/fix?

- [x] The API key input field includes a visibility toggle
- [x] The default state of the API key is hidden (masked with dots) with a hidden eye icon at the end of the input field
- [x] Clicking the visibility toggle icon reveals the API key with the visible eye icon
- [x] Each API key input field includes a placeholder text indicating the type of key

#### Screenshots

https://github.com/user-attachments/assets/c3681e59-406b-4257-8258-eff485126ef8

#### Any other comments?

No