### PR TITLE
Fix root element reuse in content script

### DIFF
--- a/src/content_script.tsx
+++ b/src/content_script.tsx
@@ -224,9 +224,13 @@ const AIReviewButton = () => {
 };
 
 // Function to process the GitHub Pull Request page, and render the AIReviewButton component
+let rootElement: HTMLDivElement | null = null;
 const processGithubPullRequestPage = async () => {
-  const rootElement = document.createElement("div");
-  document.body.appendChild(rootElement);
+  if (!rootElement || !document.body.contains(rootElement)) {
+    rootElement = document.createElement("div");
+    document.body.appendChild(rootElement);
+  }
+
   createRoot(rootElement).render(<AIReviewButton />);
 
   /* Add a watcher to detect changes in the DOM, and re-render the AIReviewButton component if it's not present */


### PR DESCRIPTION
## Summary
- avoid adding multiple AI review containers when navigating

## Testing
- `npm run lint`
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_684728892d38832c97e44e4e422d9ed4