### PR TITLE
Improve settings UI and add diff parser tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "eslint-plugin-react-hooks": "^5.1.0-rc.0",
         "eslint-plugin-react-refresh": "^0.4.9",
         "globals": "^15.9.0",
+        "linkedom": "^0.18.11",
         "typescript": "^5.5.3",
         "typescript-eslint": "^8.0.0",
         "vite": "^5.4.0",
@@ -1729,6 +1730,13 @@
         "node": ">=0.6"
       }
     },
+    "node_modules/boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -1929,6 +1937,43 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css-select": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.1.0.tgz",
+      "integrity": "sha512-nwoRF1rvRRnnCqqY7updORDsuqKzqYJ28+oSMaJMMgOauh3fvwHqMS7EZpIPqK8GL+g9mKxF1vP/ZjSeNjEVHg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-what": "^6.1.0",
+        "domhandler": "^5.0.2",
+        "domutils": "^3.0.1",
+        "nth-check": "^2.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/css-what": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.1.0.tgz",
+      "integrity": "sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/cssom": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.5.0.tgz",
+      "integrity": "sha512-iKuQcq+NdHqlAcwUY0o/HL69XQrUaQdMjmStJ8JFmUaiiQErlhrmuigkg/CU4E2J0IyUKUrMAgl36TvN67MqTw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/csstype": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
@@ -2012,11 +2057,83 @@
         "node": ">=8"
       }
     },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.6",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.6.tgz",
       "integrity": "sha512-jwXWsM5RPf6j9dPYzaorcBSUg6AiqocPEyMpkchkvntaH9HGfOOMZwxMJjDY/XEs3T5dM7uyH1VhRMkqUU9qVw==",
       "dev": true
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
     },
     "node_modules/esbuild": {
       "version": "0.21.5",
@@ -2601,6 +2718,46 @@
         "node": ">=4"
       }
     },
+    "node_modules/html-escaper": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-3.0.3.tgz",
+      "integrity": "sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/htmlparser2": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.0.0.tgz",
+      "integrity": "sha512-TwAZM+zE5Tq3lrEHvOlvwgj1XLWQCtaaibSN11Q+gGBAS7Y1uZSWwXXRe4iF6OXnaq1riyQAPFOBtYc77Mxq0g==",
+      "dev": true,
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.1",
+        "entities": "^6.0.0"
+      }
+    },
+    "node_modules/htmlparser2/node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/human-signals": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
@@ -2802,6 +2959,20 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/linkedom": {
+      "version": "0.18.11",
+      "resolved": "https://registry.npmjs.org/linkedom/-/linkedom-0.18.11.tgz",
+      "integrity": "sha512-K03GU3FUlnhBAP0jPb7tN7YJl7LbjZx30Z8h6wgLXusnKF7+BEZvfEbdkN/lO9LfFzxN3S0ZAriDuJ/13dIsLA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "css-select": "^5.1.0",
+        "cssom": "^0.5.0",
+        "html-escaper": "^3.0.3",
+        "htmlparser2": "^10.0.0",
+        "uhyphen": "^0.2.0"
       }
     },
     "node_modules/local-pkg": {
@@ -3040,6 +3211,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/nth-check": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/nth-check?sponsor=1"
       }
     },
     "node_modules/oblivious-set": {
@@ -3768,6 +3952,13 @@
       "integrity": "sha512-9a4/uxlTWJ4+a5i0ooc1rU7C7YOw3wT+UGqdeNNHWnOF9qcMBgLRS+4IYUqbczewFx4mLEig6gawh7X6mFlEkA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/uhyphen": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/uhyphen/-/uhyphen-0.2.0.tgz",
+      "integrity": "sha512-qz3o9CHXmJJPGBdqzab7qAYuW8kQGKNEuoHFYrBwV6hWIMcpAmxDLXojcHfFr9US1Pe6zUswEIJIbLI610fuqA==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/undici-types": {
       "version": "6.13.0",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "typescript": "^5.5.3",
     "typescript-eslint": "^8.0.0",
     "vite": "^5.4.0",
-    "vitest": "^1.5.0"
+    "vitest": "^1.5.0",
+    "linkedom": "^0.18.11"
   }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import {
 import {
   defaultGenerativeAiSettings,
   availableModels,
+  availableGroqModels,
   CHATGPT_MODELS_URL,
 } from "./constants";
 import { GenerativeAiConnector } from "./types";
@@ -130,7 +131,7 @@ const SettingsComponent: React.FC = () => {
     }
   }, [showGenerativeAiSuccess]);
 
-  const handleSaveSettings = () => {
+  const handleSaveAll = () => {
     updateGenerativeAiSettings({
       id: "default",
       openAiApiKey,
@@ -142,12 +143,19 @@ const SettingsComponent: React.FC = () => {
       defaultGenerativeAiConnector:
         defaultGenerativeAiConnector as GenerativeAiConnector,
     });
+    updateGithubAuthToken(authToken);
+    setShowGithubTokenSuccess(true);
     setShowGenerativeAiSuccess(true);
   };
 
-  const handleSaveGithubToken = () => {
-    updateGithubAuthToken(authToken);
-    setShowGithubTokenSuccess(true);
+  const handleCancel = () => {
+    setOpenAiApiKey(generativeAiSettings.openAiApiKey);
+    setGroqApiKey(generativeAiSettings.groqApiKey);
+    setCustomPrompt(generativeAiSettings.customPrompt);
+    setCustomPromptRole(generativeAiSettings.customPromptRole);
+    setDefaultOpenAiModel(generativeAiSettings.defaultOpenAiModel);
+    setDefaultGroqModel(generativeAiSettings.defaultGroqModel);
+    setAuthToken(githubAuthToken);
   };
 
   const handleModelReset = () => {
@@ -165,7 +173,10 @@ const SettingsComponent: React.FC = () => {
 
   return (
     <div>
-      <h2>Generative AI Connector Settings</h2>
+      <h2>
+        <span role="img" aria-label="lightning">⚡</span> Generative AI Connector
+        Settings
+      </h2>
       <fieldset>
         <label>
           Select Connector:
@@ -211,21 +222,23 @@ const SettingsComponent: React.FC = () => {
             <label>
               Select Model:
               <br />
-              <input
-                type="text"
+              <select
                 value={defaultOpenAiModel}
                 onChange={(e) => setDefaultOpenAiModel(e.target.value)}
-                list="modelOptions"
-              />
+              >
+                {availableModels.map((m) => (
+                  <option key={m} value={m}>
+                    {m}
+                  </option>
+                ))}
+              </select>
             </label>
-            <datalist id="modelOptions">
-              <option value="gpt-4o" />
-              <option value="gpt-4o-mini" />
-              <option value="gpt-4o-turbo" />
-              <option value="gpt-4" />
-              <option value="gpt-3.5-turbo" />
-            </datalist>
-            <button onClick={handleModelReset}>Reset to default</button>
+            <button
+              disabled={defaultOpenAiModel === defaultGenerativeAiSettings.defaultOpenAiModel}
+              onClick={handleModelReset}
+            >
+              ↺ Reset to default
+            </button>
             <p>Here are some available ChatGPT model options:</p>
             <p>
               <b>
@@ -275,13 +288,23 @@ const SettingsComponent: React.FC = () => {
             <label>
               Model:
               <br />
-              <input
-                type="text"
+              <select
                 value={defaultGroqModel}
                 onChange={(e) => setDefaultGroqModel(e.target.value)}
-              />
+              >
+                {availableGroqModels.map((m) => (
+                  <option key={m} value={m}>
+                    {m}
+                  </option>
+                ))}
+              </select>
             </label>
-            <button onClick={handleModelReset}>Reset to default</button>
+            <button
+              disabled={defaultGroqModel === defaultGenerativeAiSettings.defaultGroqModel}
+              onClick={handleModelReset}
+            >
+              ↺ Reset to default
+            </button>
           </fieldset>
         </>
       )}
@@ -312,9 +335,10 @@ const SettingsComponent: React.FC = () => {
       </fieldset>
 
       {showGenerativeAiSuccess && <div>Settings saved successfully!</div>}
-      <button onClick={handleSaveSettings}>Save Settings</button>
 
-      <h2>GitHub Settings</h2>
+      <h2>
+        <span role="img" aria-label="octopus">🐙</span> GitHub Settings
+      </h2>
       <fieldset>
         <label>
           Auth Token:
@@ -326,7 +350,8 @@ const SettingsComponent: React.FC = () => {
         </label>
       </fieldset>
       {showGithubTokenSuccess && <div>GitHub token saved successfully!</div>}
-      <button onClick={handleSaveGithubToken}>Save GitHub Token</button>
+      <button onClick={handleSaveAll}>Save Settings</button>
+      <button onClick={handleCancel}>Cancel</button>
     </div>
   );
 };

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -32,7 +32,9 @@ export const availableModels = [
   "gpt-4o-turbo",
   "gpt-4",
   "gpt-3.5-turbo",
-]; 
+];
+
+export const availableGroqModels = ["llama-3.1-70b-versatile", "llama3-8b"];
 
 export const defaultGenerativeAiSettings: GenerativeAiSettings = {
   id: "default",

--- a/src/content_script.tsx
+++ b/src/content_script.tsx
@@ -31,35 +31,7 @@ interface ReviewContainerProps {
   // reviewContainerElement: HTMLDivElement;
 }
 
-function parseHtmlToGitDiff(htmlString: string) {
-  const parser = new DOMParser();
-  const doc = parser.parseFromString(htmlString, "text/html");
-  const rows = doc.querySelectorAll("tbody tr");
-
-  const diffLines: string[] = [];
-
-  rows.forEach((row) => {
-    const additionCell = row.querySelector(".blob-code-addition");
-    const deletionCell = row.querySelector(".blob-code-deletion");
-    const contextCell = row.querySelector(".blob-code-context");
-    const hunkHeaderCell = row.querySelector(".blob-code-hunk");
-    const innerCell = row.querySelector(".blob-code-inner");
-
-    if (hunkHeaderCell?.textContent) {
-      diffLines.push(hunkHeaderCell.textContent.trim());
-    } else if (additionCell?.textContent) {
-      diffLines.push(`+${additionCell.textContent.trim()}`);
-    } else if (deletionCell?.textContent) {
-      diffLines.push(`-${deletionCell.textContent.trim()}`);
-    } else if (contextCell?.textContent) {
-      diffLines.push(` ${contextCell.textContent.trim()}`);
-    } else if (innerCell?.textContent) {
-      diffLines.push(` ${innerCell.textContent.trim()}`);
-    }
-  });
-
-  return diffLines.join("\n");
-}
+import { parseHtmlToGitDiff } from "./utils/parse_git_diff";
 
 // eslint-disable-next-line react-refresh/only-export-components
 const ReviewContainer = ({ isOpen, diffHtml, file }: ReviewContainerProps) => {

--- a/src/utils/__tests__/parse_git_diff.test.ts
+++ b/src/utils/__tests__/parse_git_diff.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from 'vitest';
+import { parseHtmlToGitDiff } from '../parse_git_diff';
+
+const diffHtml = `
+<table><tbody>
+<tr><td class="blob-code-hunk">@@ -1,2 +1,2 @@</td></tr>
+<tr><td class="blob-code-deletion">old line</td></tr>
+<tr><td class="blob-code-addition">new line</td></tr>
+</tbody></table>`;
+
+describe('parseHtmlToGitDiff', () => {
+  it('converts HTML diff to unified diff format', () => {
+    const result = parseHtmlToGitDiff(diffHtml);
+    expect(result).toBe('@@ -1,2 +1,2 @@\n-old line\n+new line');
+  });
+});

--- a/src/utils/parse_git_diff.ts
+++ b/src/utils/parse_git_diff.ts
@@ -1,0 +1,36 @@
+export function parseHtmlToGitDiff(htmlString: string): string {
+  let DOMParserImpl: typeof DOMParser;
+  if (typeof DOMParser === "undefined") {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    DOMParserImpl = require("linkedom").DOMParser;
+  } else {
+    DOMParserImpl = DOMParser;
+  }
+  const parser = new DOMParserImpl();
+  const doc = parser.parseFromString(htmlString, "text/html");
+  const rows = doc.querySelectorAll("tbody tr");
+
+  const diffLines: string[] = [];
+
+  rows.forEach((row) => {
+    const additionCell = row.querySelector(".blob-code-addition");
+    const deletionCell = row.querySelector(".blob-code-deletion");
+    const contextCell = row.querySelector(".blob-code-context");
+    const hunkHeaderCell = row.querySelector(".blob-code-hunk");
+    const innerCell = row.querySelector(".blob-code-inner");
+
+    if (hunkHeaderCell?.textContent) {
+      diffLines.push(hunkHeaderCell.textContent.trim());
+    } else if (additionCell?.textContent) {
+      diffLines.push(`+${additionCell.textContent.trim()}`);
+    } else if (deletionCell?.textContent) {
+      diffLines.push(`-${deletionCell.textContent.trim()}`);
+    } else if (contextCell?.textContent) {
+      diffLines.push(` ${contextCell.textContent.trim()}`);
+    } else if (innerCell?.textContent) {
+      diffLines.push(` ${innerCell.textContent.trim()}`);
+    }
+  });
+
+  return diffLines.join("\n");
+}


### PR DESCRIPTION
## Summary
- add `availableGroqModels` constant
- add lightning/octopus icons to settings headers
- use dropdowns for model selection with reset buttons
- unify save/cancel actions for all settings
- extract `parseHtmlToGitDiff` util and test it
- add `linkedom` as a dev dependency

## Testing
- `npm run lint --silent`
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_684728b50738832cb86b94baaa3059aa