### PR TITLE
Add Playwright end-to-end testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,21 @@ Source: [docs](https://vitejs.dev/)
 - Use the node version specified in `.nvmrc` (currently v20.15.1).
 - Run `npm run dev` to start Vite in development mode and `npm run build` to generate the production bundle.
 
+## Testing
+
+Run unit tests using:
+
+```bash
+npm test
+```
+
+End-to-end tests are powered by [Playwright](https://playwright.dev/). Install the browsers once and then execute the tests:
+
+```bash
+npx playwright install
+npm run test:e2e
+```
+
 ## Contributing
 
 Thank you for considering contributing to the project. Please read the [CONTRIBUTING.md](CONTRIBUTING.md) file for more information before you start contributing.

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.8.0",
+        "@playwright/test": "^1.42.0",
         "@types/chrome": "^0.0.269",
         "@types/node": "^22.2.0",
         "@types/react": "^18.3.3",
@@ -941,6 +942,22 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.52.0.tgz",
+      "integrity": "sha512-uh6W7sb55hl7D6vsAeA+V2p5JnlAqzhqFyF0VcJkKZXkgnFcVG9PziERRHQfPLfNGx1C292a4JqbWzhR8L4R1g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.52.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
@@ -3402,6 +3419,53 @@
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/playwright": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.52.0.tgz",
+      "integrity": "sha512-JAwMNMBlxJ2oD1kce4KPtMkDeKGHQstdpFPcPH3maElAXon/QZeTvtsfXmTMRyO9TslfoYOXkSsvao2nE1ilTw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.52.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.52.0.tgz",
+      "integrity": "sha512-l2osTgLXSMeuLZOML9qYODUQoPPnUsKsb5/P6LJ2e6uPKXUdPK5WYhN4z03G+YNbWmGDY4YENauNu4ZKczreHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
     },
     "node_modules/postcss": {
       "version": "8.4.41",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "build": "tsc -b && vite build && vite build --config vite.config.content_script.ts && vite build --config vite.config.background.ts",
     "lint": "eslint .",
     "preview": "vite preview",
-    "test": "vitest run"
+    "test": "vitest run",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "dexie": "^4.0.8",
@@ -40,6 +41,7 @@
     "typescript-eslint": "^8.0.0",
     "vite": "^5.4.0",
     "vitest": "^1.5.0",
-    "linkedom": "^0.18.11"
+    "linkedom": "^0.18.11",
+    "@playwright/test": "^1.42.0"
   }
 }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests',
+  webServer: {
+    command: 'npm run build && npm run preview -- --port=5173',
+    url: 'http://localhost:5173',
+    reuseExistingServer: !process.env.CI,
+    timeout: 120 * 1000,
+  },
+  use: {
+    baseURL: 'http://localhost:5173',
+    headless: true,
+  },
+});

--- a/tests/e2e.spec.ts
+++ b/tests/e2e.spec.ts
@@ -1,0 +1,6 @@
+import { test, expect } from '@playwright/test';
+
+test('popup page loads', async ({ page }) => {
+  await page.goto('/');
+  await expect(page.locator('text=GitHub Settings')).toBeVisible();
+});


### PR DESCRIPTION
## Summary
- add basic Playwright configuration
- write a sample e2e test
- document unit and e2e tests in README
- install Playwright test dependency

## Testing
- `npm test`
- `npx -y playwright install` *(fails: server returned code 403)*
- `npm run test:e2e` *(fails: Process from config.webServer exited early)*

------
https://chatgpt.com/codex/tasks/task_e_68477a39e4c8832c80d8422d15576ad3