### PR TITLE
Add unified Save Settings with cancel button

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -36,3 +36,21 @@
   width: 32px;
   height: 32px;
 }
+
+.action-buttons {
+  display: flex;
+  gap: 8px;
+  margin-top: 16px;
+}
+
+.save-settings-btn,
+.cancel-btn {
+  width: 126px;
+  height: 40px;
+  border-radius: 8px;
+  color: #f5f5f5;
+}
+
+.cancel-btn {
+  margin-right: 0;
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -350,8 +350,10 @@ const SettingsComponent: React.FC = () => {
         </label>
       </fieldset>
       {showGithubTokenSuccess && <div>GitHub token saved successfully!</div>}
-      <button onClick={handleSaveAll}>Save Settings</button>
-      <button onClick={handleCancel}>Cancel</button>
+      <div className="action-buttons">
+        <button className="cancel-btn" onClick={handleCancel}>Cancel</button>
+        <button className="save-settings-btn" onClick={handleSaveAll}>Save Settings</button>
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
it closes #17 

## Summary
- add Cancel button and Save Settings button container
- style Save Settings button according to requirements

## Testing
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68477ca4668c832c82f11d91c5ce88c8