### PR TITLE
Add additional Playwright e2e test

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from '@playwright/test';
 
 export default defineConfig({
   testDir: './tests',
+  testMatch: '**/*.e2e.ts',
   webServer: {
     command: 'npm run build && npm run preview -- --port=5173',
     url: 'http://localhost:5173',

--- a/tests/e2e.playwright.ts
+++ b/tests/e2e.playwright.ts
@@ -1,7 +1,0 @@
-if (!import.meta.vitest) {
-  const { test, expect } = await import('@playwright/test');
-  test('popup page loads', async ({ page }) => {
-    await page.goto('/');
-    await expect(page.locator('text=GitHub Settings')).toBeVisible();
-  });
-}

--- a/tests/popup.e2e.ts
+++ b/tests/popup.e2e.ts
@@ -1,0 +1,15 @@
+if (!import.meta.vitest) {
+  const { test, expect } = await import('@playwright/test');
+
+  test('popup page loads', async ({ page }) => {
+    await page.goto('/');
+    await expect(page.locator('text=GitHub Settings')).toBeVisible();
+  });
+
+  test('saving settings shows success messages', async ({ page }) => {
+    await page.goto('/');
+    await page.click('text=Save Settings');
+    await expect(page.locator('text=GitHub token saved successfully!')).toBeVisible();
+    await expect(page.locator('text=Settings saved successfully!')).toBeVisible();
+  });
+}


### PR DESCRIPTION
## Summary
- rename existing Playwright test to use `.e2e.ts` extension
- configure Playwright to match `.e2e.ts` tests
- add test verifying save action shows success messages

## Testing
- `npm test`
- `npm run test:e2e`


------
https://chatgpt.com/codex/tasks/task_e_684caac645c4832cad5479c81c286c54